### PR TITLE
v0.0.5

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,4 @@ test/
 coverage
 .nyc_output
 Makefile
+*.env

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,5 @@ logs/
 package-lock.json
 *.bak
 lb_settings.json
-.env
 .nyc_output
 coverage

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
                 volumes:
                     - "/home/umbrel/lnd:/lnd"
                 environment:
-                    BITCOIN_NETWORK: "mainnet"
                     BITCOIN_HOST: "0.0.0.0"
+                    RPC_PORT: "8332"
                     RPC_USER: "<your rpc username>"
                     RPC_PASSWORD: "<your rpc password>"
                     LND_NETWORK: "mainnet"

--- a/app.js
+++ b/app.js
@@ -1,5 +1,7 @@
 require('module-alias/register');
 require('module-alias').addPath('.');
+require('dotenv').config();
+
 const express = require('express');
 const path = require('path');
 const morgan = require('morgan');
@@ -36,7 +38,7 @@ app.use(onionOriginMiddleware);
 app.use(cors(corsOptions));
 
 app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({extended: true}));
+app.use(bodyParser.urlencoded({ extended: true }));
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(passport.initialize());
 app.use(passport.session());

--- a/logic/bitcoind.js
+++ b/logic/bitcoind.js
@@ -4,7 +4,7 @@ const BitcoindError = require('models/errors.js').BitcoindError;
 async function getBlockCount() {
   const blockCount = await bitcoindService.getBlockCount();
 
-  return {blockCount: blockCount.result};
+  return { blockCount: blockCount.result };
 }
 
 async function getConnectionsCount() {
@@ -13,7 +13,7 @@ async function getConnectionsCount() {
   var outBoundConnections = 0;
   var inBoundConnections = 0;
 
-  peerInfo.result.forEach(function(peer) {
+  peerInfo.result.forEach(function (peer) {
     if (peer.inbound === false) {
       outBoundConnections++;
 
@@ -35,10 +35,10 @@ async function getStatus() {
   try {
     await bitcoindService.help();
 
-    return {operational: true};
+    return { operational: true };
   } catch (error) {
     if (error instanceof BitcoindError) {
-      return {operational: false};
+      return { operational: false };
     }
 
     throw error;
@@ -53,7 +53,7 @@ async function getMaxSyncHeader() {
     return -1;
   }
 
-  const maxPeer = peerInfo.reduce(function(prev, current) {
+  const maxPeer = peerInfo.reduce(function (prev, current) {
     return prev.syncedHeaders > current.syncedHeaders ? prev : current;
   });
 
@@ -68,13 +68,14 @@ async function getLocalSyncInfo() {
   const info = await bitcoindService.getBlockChainInfo();
 
   var blockChainInfo = info.result;
-
+  var chain = blockChainInfo.chain;
   var blockCount = blockChainInfo.blocks;
   var headerCount = blockChainInfo.headers;
 
   const percentSynced = (Math.trunc(blockCount / headerCount * 10000) / 10000).toFixed(4); // eslint-disable-line no-magic-numbers, max-len
 
   return {
+    chain: chain,
     percent: percentSynced,
     currentBlock: blockCount,
     headerCount: headerCount // eslint-disable-line object-shorthand,
@@ -99,7 +100,7 @@ async function getVersion() {
   // Remove all non-digits or decimals.
   const version = unformattedVersion.replace(/[^\d.]/g, '');
 
-  return {version: version}; // eslint-disable-line object-shorthand
+  return { version: version }; // eslint-disable-line object-shorthand
 }
 
 async function getBlock(hash) {
@@ -165,11 +166,11 @@ async function nodeStatusSummary() {
   const miningInfo = await bitcoindService.getMiningInfo();
 
   return {
-      difficulty: blockchainInfo.result.difficulty,
-      size: blockchainInfo.result.sizeOnDisk,
-      mempool: mempoolInfo.result.bytes,
-      connections: networkInfo.result.connections,
-      networkhashps: miningInfo.result.networkhashps
+    difficulty: blockchainInfo.result.difficulty,
+    size: blockchainInfo.result.sizeOnDisk,
+    mempool: mempoolInfo.result.bytes,
+    connections: networkInfo.result.connections,
+    networkhashps: miningInfo.result.networkhashps
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umbrel-middleware",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Middleware for Umbrel Node",
   "author": "Umbrel",
   "scripts": {
@@ -18,6 +18,7 @@
     "continuation-local-storage": "^3.2.1",
     "cors": "^2.8.5",
     "debug": "^2.6.1",
+    "dotenv": "^8.2.0",
     "express": "^4.16.3",
     "grpc": "^1.8.0",
     "module-alias": "^2.1.0",

--- a/routes/v1/bitcoind/info.js
+++ b/routes/v1/bitcoind/info.js
@@ -51,14 +51,14 @@ router.get('/stats', auth.jwt, safeHandler((req, res) =>
 ));
 
 router.get('/block', auth.jwt, safeHandler((req, res) => {
-    if (req.query.hash !== undefined && req.query.hash !== null) {
-      bitcoind.getBlock(req.query.hash)
-        .then(blockhash => res.json(blockhash))
-    } else if (req.query.height !== undefined && req.query.height !== null) {
-      bitcoind.getBlockHash(req.query.height)
-        .then(blockhash => res.json(blockhash))
-    }
+  if (req.query.hash !== undefined && req.query.hash !== null) {
+    bitcoind.getBlock(req.query.hash)
+      .then(blockhash => res.json(blockhash))
+  } else if (req.query.height !== undefined && req.query.height !== null) {
+    bitcoind.getBlockHash(req.query.height)
+      .then(blockhash => res.json(blockhash))
   }
+}
 ));
 
 // /v1/bitcoind/info/block/<hash>
@@ -67,7 +67,7 @@ router.get('/block/:id', auth.jwt, safeHandler((req, res) =>
     .then(blockhash => res.json(blockhash))
 ));
 
-router.get('/txid/:id', auth.jwt, safeHandler((req,res) =>
+router.get('/txid/:id', auth.jwt, safeHandler((req, res) =>
   bitcoind.getTransaction(req.params.id)
     .then(txhash => res.json(txhash))
 ));

--- a/services/bitcoind.js
+++ b/services/bitcoind.js
@@ -3,7 +3,7 @@ const camelizeKeys = require('camelize-keys');
 
 const BitcoindError = require('models/errors.js').BitcoindError;
 
-const BITCOIND_RPC_PORT = process.env.BITCOIN_NETWORK === 'testnet' ? 18332 : 8332; // eslint-disable-line no-magic-numbers, max-len
+const BITCOIND_RPC_PORT = process.env.RPC_PORT || 8332; // eslint-disable-line no-magic-numbers, max-len
 const BITCOIND_HOST = process.env.BITCOIN_HOST || '127.0.0.1';
 const BITCOIND_RPC_USER = process.env.RPC_USER;
 const BITCOIND_RPC_PASSWORD = process.env.RPC_PASSWORD;
@@ -97,7 +97,7 @@ function getNetworkInfo() {
 }
 
 function getMiningInfo() {
-    return promiseify(rpcClient, rpcClient.getMiningInfo, 'mining info');
+  return promiseify(rpcClient, rpcClient.getMiningInfo, 'mining info');
 }
 function help() {
   // TODO: missing from the library, but can add it not sure how to package.


### PR DESCRIPTION
The idea is to merge this PR and release v0.0.5 middleware on umbrel-dashboard [v0.1.1 release](https://github.com/getumbrel/umbrel-dashboard/milestone/2). Until then, accumulating changes here.

### Changelog

- `GET /v1/bitcoind/info/sync` now also returns `chain` (regtest, test, main)
- Added `.env` support. Place this file in the project root with all the environment variables (particularly useful for local development).
- Removed `BITCOIN_NETWORK` env variable previously used to determine RPC port, and added `RPC_PORT` environment variable to explicitly define the same instead.