### PR TITLE
LND sync remove -1

### DIFF
--- a/logic/lightning.js
+++ b/logic/lightning.js
@@ -595,13 +595,12 @@ async function getSyncStatus() {
     percentSynced = ((info.bestHeaderTimestamp - genesisTimestamp) / (currentTime - genesisTimestamp))
       .toFixed(4); // eslint-disable-line no-magic-numbers
 
-    // let's not return a value over the 100% or processedBlocks > blockHeight
-    // space-fleet can determine how to handle this error state if it detects -1
+    // let's not return a value over the 100% or when processedBlocks > blockHeight
     if (percentSynced < 1.0) {
       processedBlocks = Math.floor(percentSynced * info.blockHeight);
     } else {
-      processedBlocks = -1;
-      percentSynced = -1;
+      processedBlocks = info.blockHeight;
+      percentSynced = (1).toFixed(4);
     }
 
   } else {


### PR DESCRIPTION
Don't return `-1` if processed blocks > known blocks. Instead, return `1.0000` signifying complete sync. This can happen on regtest.