### PR TITLE
Update to documentation to make it clear that default pathnames are different

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Set the following environment variables directly or by placing them in `.env` fi
 | `RPC_USER` | `bitcoind` RPC username  |  |
 | `RPC_PASSWORD` | `bitcoind` RPC password |  |
 | `LND_HOST` | IP or domain where `lnd` RPC is listening | `127.0.0.1` |
-| `TLS_FILE` | Path to `lnd`'s TLS certificate | `/lnd/tls.cert` |
+| `TLS_FILE` | Path to `lnd`'s TLS certificate | Defaults to (This is the pathname in docker): `/lnd/tls.cert` |
 | `LND_PORT` | Port where `lnd` RPC is listening | `10009` |
 | `LND_NETWORK` | The chain `bitcoind` is running on (mainnet, testnet, regtest, simnet) | `mainnet` |
 | `MACAROON_DIR` | Path to `lnd`'s `admin.macroon` file | Defaults to (This is the pathname in docker): `/lnd/data/chain/bitcoin/mainnet/admin.macaroon` |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Set the following environment variables directly or by placing them in `.env` fi
 | `TLS_FILE` | Path to `lnd`'s TLS certificate | `/lnd/tls.cert` |
 | `LND_PORT` | Port where `lnd` RPC is listening | `10009` |
 | `LND_NETWORK` | The chain `bitcoind` is running on (mainnet, testnet, regtest, simnet) | `mainnet` |
-| `MACAROON_DIR` | Path to `lnd`'s `admin.macroon` file | `/lnd/data/chain/bitcoin/mainnet/admin.macaroon` |
+| `MACAROON_DIR` | Path to `lnd`'s `admin.macroon` file | Defaults to (This is the pathname in docker): `/lnd/data/chain/bitcoin/mainnet/admin.macaroon` |
 | `JWT_PUBLIC_KEY_FILE` | Path to the JWT public key created by [`umbrel-manager`](https://github.com/getumbrel/umbrel-manager) | `/jwt-public-key/jwt.pem` |
 
 ### Step 3. Run middleware


### PR DESCRIPTION
Update to documentation to make it clear that default pathnames are different and more specific to Docker.