### PR TITLE
Support for bech32 addresses by default

### DIFF
--- a/services/lnd.js
+++ b/services/lnd.js
@@ -187,7 +187,7 @@ async function estimateFee(address, amt, confTarget) {
 
 async function generateAddress() {
   const rpcPayload = {
-    type: 1
+    type: 0
   };
 
   const conn = await initializeRPCClient();


### PR DESCRIPTION
I think its time to go bech32 only.

The benefits are that money is saved in fees, and all modern wallets now support this. Even exchanges support this. Not that I recommend anyone deposit money from an exchange and easily DOX themselves.

Closes #51 