### PR TITLE
Allow opening channels with unconfirmed inputs.

### DIFF
--- a/logic/lightning.js
+++ b/logic/lightning.js
@@ -104,6 +104,9 @@ function decodePaymentRequest(paymentRequest) {
 // generate our own unused address and then feed that into the existing call. Then we add an extra 10 sats per
 // feerateSatPerByte. This is because the actual cost is slightly more than the default one output estimate.
 async function estimateChannelOpenFee(amt, confTarget, sweep) {
+
+  // TODO: Make this work with spend_unconfirmed
+
   const address = (await generateAddress()).address;
   const baseFeeEstimate = await estimateFee(address, amt, confTarget, sweep);
 

--- a/services/lnd.js
+++ b/services/lnd.js
@@ -339,6 +339,7 @@ function openChannel(pubKey, amt, satPerByte) {
   const rpcPayload = {
     node_pubkey_string: pubKey,
     local_funding_amount: amt,
+    spend_unconfirmed: true,
   };
 
   if (satPerByte) {


### PR DESCRIPTION
Resolves https://github.com/getumbrel/umbrel/issues/303

>Currently, we don't allow opening channels with unconfirmed UTXOs, which results in poor UX. The user has to wait for funds to confirm after every deposit or channel open/close transaction to open a new channel. This can easily be fixed by [setting `spend_unconfirmed` to `true`](https://api.lightning.community/#openchannel) in the channel open gRPC.

- @mayankchhabra 