### PR TITLE
Use verificationProgress rather than count blocks

### DIFF
--- a/logic/bitcoind.js
+++ b/logic/bitcoind.js
@@ -71,8 +71,8 @@ async function getLocalSyncInfo() {
   var chain = blockChainInfo.chain;
   var blockCount = blockChainInfo.blocks;
   var headerCount = blockChainInfo.headers; 
-  
-  var percentSynced = (parseFloat(blockChainInfo.verificationprogress) * 100).toFixed(2);
+
+  var percentSynced = (blockChainInfo.verificationprogress * 100).toFixed(2);
 
   return {
     chain: chain,

--- a/logic/bitcoind.js
+++ b/logic/bitcoind.js
@@ -70,9 +70,8 @@ async function getLocalSyncInfo() {
   var blockChainInfo = info.result;
   var chain = blockChainInfo.chain;
   var blockCount = blockChainInfo.blocks;
-  var headerCount = blockChainInfo.headers;
-
-  const percentSynced = (Math.trunc(blockCount / headerCount * 10000) / 10000).toFixed(4); // eslint-disable-line no-magic-numbers, max-len
+  var headerCount = blockChainInfo.headers; 
+  var percentSynced = blockChainInfo.verificationprogress;
 
   return {
     chain: chain,

--- a/logic/bitcoind.js
+++ b/logic/bitcoind.js
@@ -71,11 +71,11 @@ async function getLocalSyncInfo() {
   var chain = blockChainInfo.chain;
   var blockCount = blockChainInfo.blocks;
   var headerCount = blockChainInfo.headers; 
-  var percentSynced = blockChainInfo.verificationprogress;
+  var percent = blockChainInfo.verificationprogress;
 
   return {
-    chain: chain,
-    percent: percentSynced,
+    chain,
+    percent,
     currentBlock: blockCount,
     headerCount: headerCount // eslint-disable-line object-shorthand,
   };

--- a/logic/bitcoind.js
+++ b/logic/bitcoind.js
@@ -71,7 +71,8 @@ async function getLocalSyncInfo() {
   var chain = blockChainInfo.chain;
   var blockCount = blockChainInfo.blocks;
   var headerCount = blockChainInfo.headers; 
-  var percentSynced = blockChainInfo.verificationprogress;
+  
+  var percentSynced = (parseFloat(blockChainInfo.verificationprogress) * 100).toFixed(2);
 
   return {
     chain: chain,

--- a/logic/bitcoind.js
+++ b/logic/bitcoind.js
@@ -71,8 +71,7 @@ async function getLocalSyncInfo() {
   var chain = blockChainInfo.chain;
   var blockCount = blockChainInfo.blocks;
   var headerCount = blockChainInfo.headers; 
-
-  var percentSynced = (blockChainInfo.verificationprogress * 100).toFixed(2);
+  var percentSynced = blockChainInfo.verificationprogress;
 
   return {
     chain: chain,


### PR DESCRIPTION
- This PR changes the API to use the verificationProgress returned from the bitcoind gRPC rather than calculating the remaining number of blocks

resolves https://github.com/getumbrel/umbrel/issues/243