### PR TITLE
Auto unlock LND wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Set the following environment variables directly or by placing them in `.env` fi
 | `TLS_FILE` | Path to `lnd`'s TLS certificate | `/lnd/tls.cert` |
 | `LND_PORT` | Port where `lnd` RPC is listening | `10009` |
 | `LND_NETWORK` | The chain `bitcoind` is running on (mainnet, testnet, regtest, simnet) | `mainnet` |
+| `LND_WALLET_PASSWORD` | The password for the LND wallet which will be automatically unlocked on boot | ` ` |
 | `MACAROON_DIR` | Path to `lnd`'s macaroon directory | `/lnd/data/chain/bitcoin/mainnet/` |
 | `JWT_PUBLIC_KEY_FILE` | Path to the JWT public key created by [`umbrel-manager`](https://github.com/getumbrel/umbrel-manager) | `/jwt-public-key/jwt.pem` |
 

--- a/app.js
+++ b/app.js
@@ -60,3 +60,8 @@ app.use((req, res) => {
 });
 
 module.exports = app;
+
+// LND Unlocker
+const LndUnlocker = require('logic/lnd-unlocker');
+lndUnlocker = new LndUnlocker('moneyprintergobrrr');
+lndUnlocker.start();

--- a/app.js
+++ b/app.js
@@ -9,6 +9,8 @@ const bodyParser = require('body-parser');
 const passport = require('passport');
 const cors = require('cors');
 
+const constants = require('utils/const.js');
+
 // Keep requestCorrelationId middleware as the first middleware. Otherwise we risk losing logs.
 const requestCorrelationMiddleware = require('middlewares/requestCorrelationId.js'); // eslint-disable-line id-length
 const camelCaseReqMiddleware = require('middlewares/camelCaseRequest.js').camelCaseRequest;
@@ -62,6 +64,8 @@ app.use((req, res) => {
 module.exports = app;
 
 // LND Unlocker
-const LndUnlocker = require('logic/lnd-unlocker');
-lndUnlocker = new LndUnlocker('moneyprintergobrrr');
-lndUnlocker.start();
+if (constants.LND_WALLET_PASSWORD) {
+  const LndUnlocker = require('logic/lnd-unlocker');
+  lndUnlocker = new LndUnlocker(constants.LND_WALLET_PASSWORD);
+  lndUnlocker.start();
+}

--- a/logic/lnd-unlocker.js
+++ b/logic/lnd-unlocker.js
@@ -14,7 +14,7 @@ module.exports = class LndUnlocker {
 
   async unlock() {
     try {
-      await lndService.getInfo();
+      await lightningLogic.getGeneralInfo();
       return true;
     } catch (e) {
       try {

--- a/logic/lnd-unlocker.js
+++ b/logic/lnd-unlocker.js
@@ -1,24 +1,32 @@
 const lightningLogic = require('logic/lightning');
 
-const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+const SECONDS = 1000;
+const MINUTES = 60 * SECONDS;
 
-const ONE_SECOND = 1000;
-const INTERVAL = 10 * ONE_SECOND;
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 module.exports = class LndUnlocker {
   constructor(password) {
     this.password = password;
     this.running = false;
+    this.unlocked = false;
   }
 
   async unlock() {
     try {
-      await lightningLogic.unlockWallet(this.password);
-      console.log('LndUnlocker: Wallet unlocked!');
+      await lndService.getInfo();
+      return true;
     } catch (e) {
-      console.log(`LndUnlocker: Couldn't unlock wallet`);
+      try {
+        await lightningLogic.unlockWallet(this.password);
+        console.log('LndUnlocker: Wallet unlocked!');
+        return true;
+      } catch (e) {
+        console.log('LndUnlocker: Wallet failed to unlock!');
+        return false;
+      }
     }
-  }
+  };
 
   async start() {
     if (this.running) {
@@ -26,12 +34,13 @@ module.exports = class LndUnlocker {
     }
     this.running = true;
     while (this.running) {
-      await this.unlock();
-      await delay(INTERVAL);
+      this.unlocked = await this.unlock();
+      await delay(this.unlocked ? 1 * MINUTES : 10 * SECONDS);
     }
   }
 
   stop() {
     this.running = false;
+    this.unlocked = false;
   }
 }

--- a/logic/lnd-unlocker.js
+++ b/logic/lnd-unlocker.js
@@ -15,6 +15,9 @@ module.exports = class LndUnlocker {
   async unlock() {
     try {
       await lightningLogic.getGeneralInfo();
+      if (!this.unlocked) {
+        console.log('LndUnlocker: Wallet unlocked!');
+      }
       return true;
     } catch (e) {
       try {

--- a/logic/lnd-unlocker.js
+++ b/logic/lnd-unlocker.js
@@ -1,0 +1,37 @@
+const lightningLogic = require('logic/lightning');
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const ONE_SECOND = 1000;
+const INTERVAL = 10 * ONE_SECOND;
+
+module.exports = class LndUnlocker {
+  constructor(password) {
+    this.password = password;
+    this.running = false;
+  }
+
+  async unlock() {
+    try {
+      await lightningLogic.unlockWallet(this.password);
+      console.log('LndUnlocker: Wallet unlocked!');
+    } catch (e) {
+      console.log(`LndUnlocker: Couldn't unlock wallet`);
+    }
+  }
+
+  async start() {
+    if (this.running) {
+      throw new Error('Already running');
+    }
+    this.running = true;
+    while (this.running) {
+      await this.unlock();
+      await delay(INTERVAL);
+    }
+  }
+
+  stop() {
+    this.running = false;
+  }
+}

--- a/routes/v1/lnd/wallet.js
+++ b/routes/v1/lnd/wallet.js
@@ -13,7 +13,7 @@ router.get('/btc', auth.jwt, safeHandler((req, res) =>
     .then(balance => res.json(balance))
 ));
 
-// API endpoint to change your lnd password. Wallet must exist and be unlocked.
+// API endpoint to change your lnd password.
 router.post('/changePassword', auth.jwt, safeHandler(async(req, res, next) => {
 
   const currentPassword = req.body.currentPassword;
@@ -81,11 +81,6 @@ router.get('/lightning', auth.jwt, safeHandler((req, res) =>
 router.get('/seed', safeHandler((req, res) =>
   lightningLogic.generateSeed()
     .then(seed => res.json(seed))
-));
-
-router.post('/unlock', auth.jwt, safeHandler((req, res) =>
-  lightningLogic.unlockWallet(req.body.password)
-    .then(response => res.json(response))
 ));
 
 module.exports = router;

--- a/services/lnd.js
+++ b/services/lnd.js
@@ -99,7 +99,7 @@ async function addInvoice(amount, memo) {
   }
 }
 
-// Change your lnd password. Wallet must exist and be unlocked.
+// Change your lnd password.
 async function changePassword(currentPassword, newPassword) {
 
   const currentPasswordBuff = Buffer.from(currentPassword, 'utf8');

--- a/utils/const.js
+++ b/utils/const.js
@@ -7,6 +7,7 @@ module.exports = {
   },
   JWT_PUBLIC_KEY_FILE: process.env.JWT_PUBLIC_KEY_FILE || 'UNKNOWN',
   MANAGED_CHANNELS_FILE: '/channel-data/managedChannels.json',
+  LND_WALLET_PASSWORD: process.env.LND_WALLET_PASSWORD || '',
   REQUEST_CORRELATION_NAMESPACE_KEY: 'umbrel-middleware-request',
   REQUEST_CORRELATION_ID_KEY: 'reqId',
   STATUS_CODES: {

--- a/utils/const.js
+++ b/utils/const.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   JWT_PUBLIC_KEY_FILE: process.env.JWT_PUBLIC_KEY_FILE || 'UNKNOWN',
   MANAGED_CHANNELS_FILE: '/channel-data/managedChannels.json',
-  LND_WALLET_PASSWORD: process.env.LND_WALLET_PASSWORD || '',
+  LND_WALLET_PASSWORD: process.env.LND_WALLET_PASSWORD || 'moneyprintergobrrr',
   REQUEST_CORRELATION_NAMESPACE_KEY: 'umbrel-middleware-request',
   REQUEST_CORRELATION_ID_KEY: 'reqId',
   STATUS_CODES: {


### PR DESCRIPTION
Related:
- https://github.com/getumbrel/umbrel-manager/pull/85
- https://github.com/getumbrel/umbrel-dashboard/pull/326

This PR allows manager to accept an `LND_WALLET_PASSWORD` environment variable to automatically unlock the wallet.

On startup the wallet will be attempted to be unlocked every 10 seconds until it's successfully unlocked.

Once unlocked, the wallet status will be continually monitored once a minute. If the wallet becomes locked again due to some weird circumstances or an LND restart/crash, it'll be unlocked again.